### PR TITLE
Fixed compiler errors and updated according to clap library changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
         .get_matches();
 
     match matches.subcommand() {
-        ("projects", Some(projects_matches)) => {
+        Some(("projects", projects_matches)) => {
             let all = projects_matches.is_present("all");
             println!("Cloning {}", all);
 
@@ -45,10 +45,10 @@ fn main() {
                 println!("get_all_projects is not implemented yet...")
             }
         }
-        ("history", _) => {
+        Some(("history", _)) => {
             println!("History is not implemented yet...")
         }
-        ("track", Some(track_matches)) => {
+        Some(("track", track_matches)) => {
             // Now we have a reference to add's matches
             println!(
                 "Tracking {}",
@@ -59,7 +59,7 @@ fn main() {
                     .join(", ")
             );
         }
-        (_, None) => println!("No subcommand was used"), // If no subcommand was used it'll match the tuple ("", None)
-        _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
+        Some((_, _)) => unreachable!("Unknown commands should be handled by the library"),
+        None => println!("No subcommand was used"), // If all subcommands are defined above, anything else is unreachable!()
     }
 }


### PR DESCRIPTION
Du nevnte at du hadde hatt litt problemer med Clap, Even, så jeg tok en kikk og fikset kompilasjon feil, samt litt rar håndtering av mulige subcommand situasjoner.

Hvis du ser på doc-en til `subcommand()` så vil du se at signaturen ser slik ut:
`pub fn subcommand(&self) -> Option<(&str, &ArgMatches)>`
Den returnerer altså en `Option` (type som enten kan være `Some(T)` eller `None`) med en tuple av `&str` og `&ArgMatches`.

For å lære hvordan `match` fungerer og hvorfor alle mulige situasjoner er dekket i endringene nedenfor anbefaler jeg å lese (veldig god intro): https://doc.rust-lang.org/book/ch06-02-match.html