### PR TITLE
Set version number from Cargo build metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,13 @@ mod project;
 mod timestamp;
 mod user;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 fn main() -> Result<(), Box<dyn Error>> {
+
     let matches = App::new("floq")
         .about("Floq i din lokale terminal")
-        .version("0.1")
+        .version(VERSION)
         .author("Rust-gjengen")
         .setting(AppSettings::ArgRequiredElseHelp)
         .subcommand(user::subcommand_app())


### PR DESCRIPTION
Cargo exposes a VERSION environment variable during build that we can
use to automatically update the version number we display:
<https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates>