### PR TITLE
Add flags --forrige-uke and --neste-uke to timehistorikk

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ If it's your first time using this tool, or you have changed the environment the
 
 or 
 
-`floq logg-inn`
+`floq bruker logg-inn`
 
 As stated above, you must also re-authenticate yourself whenever you're changing environment since the same configuration file is used.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ mod user;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() -> Result<(), Box<dyn Error>> {
-
     let matches = App::new("floq")
         .about("Floq i din lokale terminal")
         .version(VERSION)

--- a/src/timestamp/mod.rs
+++ b/src/timestamp/mod.rs
@@ -197,7 +197,8 @@ async fn execute<T: Write + Send>(
             let date = base_date + Duration::days(days_until_date);
 
             vec![date.naive_local()]
-        } else { // fallback to todays date
+        } else {
+            // default to todays date
             vec![Utc::now().date().naive_local()]
         }
     };


### PR DESCRIPTION
Akkurat som med timeføring synes jeg det er slitsomt å finne timer ført utenfor gjeldende uke så implementerte et par flagg for å gjøre det enklere å se forrige og neste ukes timer.

Er det godt nok å kunne enkelt se timer ført forrige/ neste uke?
Eller tror dere det også er behov for å kunne se f.eks. alt for forrige måned? (kan ha begge deler så klart)